### PR TITLE
Feature/update profile

### DIFF
--- a/Smack/Smack.xcodeproj/project.pbxproj
+++ b/Smack/Smack.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		4ADA5F6E209F0F4D002CC02A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4ADA5F6D209F0F4D002CC02A /* Assets.xcassets */; };
 		4ADA5F71209F0F4D002CC02A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4ADA5F6F209F0F4D002CC02A /* LaunchScreen.storyboard */; };
 		4ADA5F7C209F1FF7002CC02A /* SWRevealViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ADA5F7A209F1FF7002CC02A /* SWRevealViewController.m */; };
+		4ADDCBD8222BEA07004798B7 /* UpdateProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADDCBD6222BEA07004798B7 /* UpdateProfileVC.swift */; };
+		4ADDCBD9222BEA07004798B7 /* UpdateProfileVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4ADDCBD7222BEA07004798B7 /* UpdateProfileVC.xib */; };
 		CC800BFF9C0FE94CA559FBED /* Pods_Smack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76EBC43F0CAB406C37BDFD2F /* Pods_Smack.framework */; };
 /* End PBXBuildFile section */
 
@@ -72,6 +74,8 @@
 		4ADA5F79209F1FF6002CC02A /* Smack-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Smack-Bridging-Header.h"; sourceTree = "<group>"; };
 		4ADA5F7A209F1FF7002CC02A /* SWRevealViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SWRevealViewController.m; sourceTree = "<group>"; };
 		4ADA5F7B209F1FF7002CC02A /* SWRevealViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWRevealViewController.h; sourceTree = "<group>"; };
+		4ADDCBD6222BEA07004798B7 /* UpdateProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProfileVC.swift; sourceTree = "<group>"; };
+		4ADDCBD7222BEA07004798B7 /* UpdateProfileVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UpdateProfileVC.xib; sourceTree = "<group>"; };
 		76EBC43F0CAB406C37BDFD2F /* Pods_Smack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Smack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8103AF856C3129BB5CE895C /* Pods-Smack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Smack.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Smack/Pods-Smack.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -139,6 +143,7 @@
 				4AA4147F20BAB246004DAF06 /* CreateAccountVC.swift */,
 				4AC5AE2E20FB6079003E4226 /* AvatarPickerVC.swift */,
 				4AC5AE3421295213003E4226 /* ProfileVC.swift */,
+				4ADDCBD6222BEA07004798B7 /* UpdateProfileVC.swift */,
 				4A78B7F921578E34001DC11F /* AddChannelVC.swift */,
 			);
 			path = Controller;
@@ -157,6 +162,7 @@
 			children = (
 				4AC5AE3521295213003E4226 /* ProfileVC.xib */,
 				4A78B7FA21578E34001DC11F /* AddChannelVC.xib */,
+				4ADDCBD7222BEA07004798B7 /* UpdateProfileVC.xib */,
 			);
 			path = XIBs;
 			sourceTree = "<group>";
@@ -285,6 +291,7 @@
 				4ADA5F71209F0F4D002CC02A /* LaunchScreen.storyboard in Resources */,
 				4ADA5F6E209F0F4D002CC02A /* Assets.xcassets in Resources */,
 				4ADA5F6C209F0F4C002CC02A /* Main.storyboard in Resources */,
+				4ADDCBD9222BEA07004798B7 /* UpdateProfileVC.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +383,7 @@
 				4AA4147920B1629E004DAF06 /* GradientView.swift in Sources */,
 				4AC5AE3120FDB5B9003E4226 /* AvatarCell.swift in Sources */,
 				4ADA5F67209F0F4C002CC02A /* AppDelegate.swift in Sources */,
+				4ADDCBD8222BEA07004798B7 /* UpdateProfileVC.swift in Sources */,
 				4ADA5F7C209F1FF7002CC02A /* SWRevealViewController.m in Sources */,
 				4AA4147C20BA8AB9004DAF06 /* Constants.swift in Sources */,
 			);

--- a/Smack/Smack/Base.lproj/Main.storyboard
+++ b/Smack/Smack/Base.lproj/Main.storyboard
@@ -617,7 +617,7 @@
         <!--Avatar PickerVC-->
         <scene sceneID="xSo-cM-IuF">
             <objects>
-                <viewController id="hYQ-mv-1vz" customClass="AvatarPickerVC" customModule="Smack" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AvatarPicker" id="hYQ-mv-1vz" customClass="AvatarPickerVC" customModule="Smack" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wgI-dT-r4j">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Smack/Smack/Base.lproj/Main.storyboard
+++ b/Smack/Smack/Base.lproj/Main.storyboard
@@ -432,7 +432,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wZQ-6u-L9l" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1575" y="-287"/>
+            <point key="canvasLocation" x="1631" y="-287"/>
         </scene>
         <!--Create AccountVC-->
         <scene sceneID="UYX-tu-zHD">

--- a/Smack/Smack/Base.lproj/Main.storyboard
+++ b/Smack/Smack/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/Smack/Smack/Controller/AvatarPickerVC.swift
+++ b/Smack/Smack/Controller/AvatarPickerVC.swift
@@ -79,11 +79,7 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     fileprivate func setUpdateProfileVC(_ newAvatarName: String) {
         guard let updateProfileVC = presentingViewController as! UpdateProfileVC? else { return }
         updateProfileVC.userImg.image = UIImage(named: newAvatarName)
-        if UIImage(named: newAvatarName) != updateProfileVC.originalUserImg {
-            updateProfileVC.enableUpdateProfileBtn()
-        } else {
-            updateProfileVC.disableUpdateProfileBtn()
-        }
+        updateProfileVC.profileValuesDidEndEditing(self)
     }
     
 

--- a/Smack/Smack/Controller/AvatarPickerVC.swift
+++ b/Smack/Smack/Controller/AvatarPickerVC.swift
@@ -65,21 +65,28 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if avatarType == .dark {
-            UserDataService.instance.setAvatarName(avatarName: "dark\(indexPath.item)")
-            setUpdateProfileVC(UserDataService.instance.avatarName)
+            if presentingViewController?.title == "updateProfileVC" {
+                setUpdateProfileVC("dark\(indexPath.item)")
+            } else {
+                UserDataService.instance.setAvatarName(avatarName: "dark\(indexPath.item)")
+            }
             print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         } else {
-            UserDataService.instance.setAvatarName(avatarName: "light\(indexPath.item)")
-            setUpdateProfileVC(UserDataService.instance.avatarName)
+            if presentingViewController?.title == "updateProfileVC" {
+                setUpdateProfileVC("dark\(indexPath.item)")
+            } else {
+                UserDataService.instance.setAvatarName(avatarName: "light\(indexPath.item)")
+            }
             print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         }
         dismiss(animated: true, completion: nil)
     }
     
     fileprivate func setUpdateProfileVC(_ newAvatarName: String) {
-        guard let updateProfileVC = presentingViewController as! UpdateProfileVC? else { return }
-        updateProfileVC.userImg.image = UIImage(named: newAvatarName)
-        updateProfileVC.profileValuesDidEndEditing(self)
+        guard let updateProfileVC = presentingViewController as? UpdateProfileVC? else { return }
+        updateProfileVC?.userImg.image = UIImage(named: newAvatarName)
+        print("avatarPicker - userImg.image: \(newAvatarName)")
+        updateProfileVC?.profileValuesDidEndEditing(self)
     }
     
 

--- a/Smack/Smack/Controller/AvatarPickerVC.swift
+++ b/Smack/Smack/Controller/AvatarPickerVC.swift
@@ -21,6 +21,7 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
         super.viewDidLoad()
         collectionView.delegate = self
         collectionView.dataSource = self
+        print("***** Presenting view controller: \(presentingViewController?.title) *****")
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -63,10 +64,15 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let updateProfileVC = presentingViewController as! UpdateProfileVC? else { return }
         if avatarType == .dark {
             UserDataService.instance.setAvatarName(avatarName: "dark\(indexPath.item)")
+            updateProfileVC.userImg.image = UIImage(named: UserDataService.instance.avatarName)
+            print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         } else {
             UserDataService.instance.setAvatarName(avatarName: "light\(indexPath.item)")
+            updateProfileVC.userImg.image = UIImage(named: UserDataService.instance.avatarName)
+            print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         }
         dismiss(animated: true, completion: nil)
     }

--- a/Smack/Smack/Controller/AvatarPickerVC.swift
+++ b/Smack/Smack/Controller/AvatarPickerVC.swift
@@ -64,17 +64,26 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let updateProfileVC = presentingViewController as! UpdateProfileVC? else { return }
         if avatarType == .dark {
             UserDataService.instance.setAvatarName(avatarName: "dark\(indexPath.item)")
-            updateProfileVC.userImg.image = UIImage(named: UserDataService.instance.avatarName)
+            setUpdateProfileVC(UserDataService.instance.avatarName)
             print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         } else {
             UserDataService.instance.setAvatarName(avatarName: "light\(indexPath.item)")
-            updateProfileVC.userImg.image = UIImage(named: UserDataService.instance.avatarName)
+            setUpdateProfileVC(UserDataService.instance.avatarName)
             print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         }
         dismiss(animated: true, completion: nil)
+    }
+    
+    fileprivate func setUpdateProfileVC(_ newAvatarName: String) {
+        guard let updateProfileVC = presentingViewController as! UpdateProfileVC? else { return }
+        updateProfileVC.userImg.image = UIImage(named: newAvatarName)
+        if UIImage(named: newAvatarName) != updateProfileVC.originalUserImg {
+            updateProfileVC.enableUpdateProfileBtn()
+        } else {
+            updateProfileVC.disableUpdateProfileBtn()
+        }
     }
     
 

--- a/Smack/Smack/Controller/AvatarPickerVC.swift
+++ b/Smack/Smack/Controller/AvatarPickerVC.swift
@@ -65,17 +65,19 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if avatarType == .dark {
+            let selectedAvatar = "dark\(indexPath.item)"
             if presentingViewController?.title == "updateProfileVC" {
-                setUpdateProfileVC("dark\(indexPath.item)")
+                setUpdateProfileVC(selectedAvatar)
             } else {
-                UserDataService.instance.setAvatarName(avatarName: "dark\(indexPath.item)")
+                UserDataService.instance.setAvatarName(avatarName: selectedAvatar)
             }
             print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         } else {
+            let selectedAvatar = "light\(indexPath.item)"
             if presentingViewController?.title == "updateProfileVC" {
-                setUpdateProfileVC("dark\(indexPath.item)")
+                setUpdateProfileVC(selectedAvatar)
             } else {
-                UserDataService.instance.setAvatarName(avatarName: "light\(indexPath.item)")
+                UserDataService.instance.setAvatarName(avatarName: selectedAvatar)
             }
             print("***** Avatar name: \(UserDataService.instance.avatarName)) *****")
         }
@@ -85,6 +87,7 @@ class AvatarPickerVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     fileprivate func setUpdateProfileVC(_ newAvatarName: String) {
         guard let updateProfileVC = presentingViewController as? UpdateProfileVC? else { return }
         updateProfileVC?.userImg.image = UIImage(named: newAvatarName)
+        updateProfileVC?.avatarName = newAvatarName
         print("avatarPicker - userImg.image: \(newAvatarName)")
         updateProfileVC?.profileValuesDidEndEditing(self)
     }

--- a/Smack/Smack/Controller/ChatVC.swift
+++ b/Smack/Smack/Controller/ChatVC.swift
@@ -49,10 +49,7 @@ class ChatVC: UIViewController, UITableViewDelegate, UITableViewDataSource {
             if newMessage.channelId == MessageService.instance.selectedChannel?.id && AuthService.instance.isLoggedIn {
                 MessageService.instance.messages.append(newMessage)
                 self.tableView.reloadData()
-                if MessageService.instance.messages.count > 0 {
-                    let endIndex = IndexPath(row: MessageService.instance.messages.count - 1, section: 0)
-                    self.tableView.scrollToRow(at: endIndex, at: .bottom, animated: false)
-                }
+                self.scrollToBottom()
             }
         }
         
@@ -172,11 +169,19 @@ class ChatVC: UIViewController, UITableViewDelegate, UITableViewDataSource {
         }
     }
     
+    fileprivate func scrollToBottom() {
+        if MessageService.instance.messages.count > 0 {
+            let endIndex = IndexPath(row: MessageService.instance.messages.count - 1, section: 0)
+            self.tableView.scrollToRow(at: endIndex, at: .bottom, animated: true)
+        }
+    }
+    
     func getMessages() {
         guard let channelId = MessageService.instance.selectedChannel?.id else { return }
         MessageService.instance.findAllMessagesForChannel(channelId: channelId) { (success) in
             if success {
                 self.tableView.reloadData()
+                self.scrollToBottom()
             }
         }
     }

--- a/Smack/Smack/Controller/ProfileVC.swift
+++ b/Smack/Smack/Controller/ProfileVC.swift
@@ -20,6 +20,7 @@ class ProfileVC: UIViewController {
         super.viewDidLoad()
 
         setupView()
+        NotificationCenter.default.addObserver(self, selector: #selector(ProfileVC.userDataDidChange(_:)), name: NOTIF_USER_DATA_DID_CHANGE, object: nil)
     }
 
     @IBAction func updateProfilePressed(_ sender: Any) {
@@ -63,6 +64,10 @@ class ProfileVC: UIViewController {
     
     @objc func closeTap(_ recognizer: UITapGestureRecognizer) {
         dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func userDataDidChange(_ notif: Notification) {
+        setupView()
     }
     
 }

--- a/Smack/Smack/Controller/ProfileVC.swift
+++ b/Smack/Smack/Controller/ProfileVC.swift
@@ -23,6 +23,13 @@ class ProfileVC: UIViewController {
     }
 
     @IBAction func updateProfilePressed(_ sender: Any) {
+        if AuthService.instance.isLoggedIn {
+            let updateProfileVC = UpdateProfileVC()
+            updateProfileVC.modalPresentationStyle = .custom
+            present(updateProfileVC, animated: true, completion: nil)
+        } else {
+            performSegue(withIdentifier: TO_LOGIN, sender: nil)
+        }
     }
     
     @IBAction func closeModalPressed(_ sender: Any) {

--- a/Smack/Smack/Controller/ProfileVC.swift
+++ b/Smack/Smack/Controller/ProfileVC.swift
@@ -26,6 +26,7 @@ class ProfileVC: UIViewController {
         if AuthService.instance.isLoggedIn {
             let updateProfileVC = UpdateProfileVC()
             updateProfileVC.modalPresentationStyle = .custom
+            updateProfileVC.title = "updateProfileVC"
             present(updateProfileVC, animated: true, completion: nil)
         } else {
             performSegue(withIdentifier: TO_LOGIN, sender: nil)

--- a/Smack/Smack/Controller/ProfileVC.swift
+++ b/Smack/Smack/Controller/ProfileVC.swift
@@ -22,6 +22,8 @@ class ProfileVC: UIViewController {
         setupView()
     }
 
+    @IBAction func updateProfilePressed(_ sender: Any) {
+    }
     
     @IBAction func closeModalPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -83,10 +83,6 @@ class UpdateProfileVC: UIViewController {
         dismiss(animated: true, completion: nil)
     }
     
-    @IBAction func usernameChanged(_ sender: Any) {
-        print("***** \n username - Editing Changed! \n*****")
-    }
-    
     @IBAction func profileValuesDidEndEditing(_ sender: Any) {
         print("***** \n username - Editing Did End! \n*****")
         if usernameTxt.text != UserDataService.instance.name || emailTxt.text != UserDataService.instance.email || userImg.image != originalUserImg || avatarColor != UserDataService.instance.avatarColor {
@@ -96,10 +92,6 @@ class UpdateProfileVC: UIViewController {
             disableUpdateProfileBtn()
             print("***** \n UpdateProfileBtn should be disabled \n*****")
         }
-    }
-    
-    @IBAction func usernameValueChanged(_ sender: Any) {
-        print("***** \n username - Value Changed! \n*****")
     }
     
     func disableUpdateProfileBtn() {

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -102,6 +102,7 @@ class UpdateProfileVC: UIViewController {
         usernameTxt.text = UserDataService.instance.name
         emailTxt.text = UserDataService.instance.email
         originalUserImg = UIImage(named: UserDataService.instance.avatarName)
+        print("setupView - originalUserImg: \(originalUserImg)")
         userImg.image = originalUserImg
         userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
         spinner.isHidden = true

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -21,12 +21,18 @@ class UpdateProfileVC: UIViewController {
     var avatarName = "profileDefault"
     var avatarColor = "[0.5, 0.5, 0.5, 1]"
     var bgColor: UIColor?
+    var originalUserImg: UIImage?
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        print("***** Update profile VC: view did load \n*****")
         setupView()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        print("***** Update profile VC: view did appear \n*****")
     }
     
     @IBAction func pickAvatarPressed(_ sender: Any) {
@@ -54,8 +60,6 @@ class UpdateProfileVC: UIViewController {
         }
     }
     
-    
-
     @IBAction func closeBtnPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }
@@ -79,8 +83,7 @@ class UpdateProfileVC: UIViewController {
         print("***** \n username - Value Changed! \n*****")
     }
     
-    
-    fileprivate func disableUpdateProfileBtn() {
+    func disableUpdateProfileBtn() {
         if updateProfileBtn.isUserInteractionEnabled == true {
             updateProfileBtn.isUserInteractionEnabled = false
             updateProfileBtn.alpha = 0.5
@@ -88,7 +91,7 @@ class UpdateProfileVC: UIViewController {
         
     }
     
-    fileprivate func enableUpdateProfileBtn() {
+    func enableUpdateProfileBtn() {
         if updateProfileBtn.isUserInteractionEnabled == false {
             updateProfileBtn.isUserInteractionEnabled = true
             updateProfileBtn.alpha = 1
@@ -98,7 +101,8 @@ class UpdateProfileVC: UIViewController {
     func setupView() {
         usernameTxt.text = UserDataService.instance.name
         emailTxt.text = UserDataService.instance.email
-        userImg.image = UIImage(named: UserDataService.instance.avatarName)
+        originalUserImg = UIImage(named: UserDataService.instance.avatarName)
+        userImg.image = originalUserImg
         userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
         spinner.isHidden = true
         disableUpdateProfileBtn()

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -35,14 +35,48 @@ class UpdateProfileVC: UIViewController {
         dismiss(animated: true, completion: nil)
     }
     
+    @IBAction func usernameChanged(_ sender: Any) {
+        print("***** \n username - Editing Changed! \n*****")
+    }
+    
+    @IBAction func profileValuesDidEndEditing(_ sender: Any) {
+        print("***** \n username - Editing Did End! \n*****")
+        if usernameTxt.text != UserDataService.instance.name || emailTxt.text != UserDataService.instance.email {
+            enableUpdateProfileBtn()
+            print("***** \n UpdateProfileBtn should be enabled! \n*****")
+        } else {
+            disableUpdateProfileBtn()
+            print("***** \n UpdateProfileBtn should be disabled \n*****")
+        }
+    }
+    
+    @IBAction func usernameValueChanged(_ sender: Any) {
+        print("***** \n username - Value Changed! \n*****")
+    }
+    
+    
+    fileprivate func disableUpdateProfileBtn() {
+        if updateProfileBtn.isUserInteractionEnabled == true {
+            updateProfileBtn.isUserInteractionEnabled = false
+            updateProfileBtn.alpha = 0.5
+        }
+        
+    }
+    
+    fileprivate func enableUpdateProfileBtn() {
+        if updateProfileBtn.isUserInteractionEnabled == false {
+            updateProfileBtn.isUserInteractionEnabled = true
+            updateProfileBtn.alpha = 1
+        }
+    }
+    
     func setupView() {
         usernameTxt.text = UserDataService.instance.name
         emailTxt.text = UserDataService.instance.email
         userImg.image = UIImage(named: UserDataService.instance.avatarName)
         userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
         spinner.isHidden = true
-        updateProfileBtn.isUserInteractionEnabled = false
-        updateProfileBtn.alpha = 0.5
+        disableUpdateProfileBtn()
     }
 
 }

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -17,12 +17,11 @@ class UpdateProfileVC: UIViewController {
     @IBOutlet weak var spinner: UIActivityIndicatorView!
     @IBOutlet weak var updateProfileBtn: RoundedButton!
     
-    
     //MARK: Variables
     var avatarName = "profileDefault"
     var avatarColor = "[0.5, 0.5, 0.5, 1]"
     var bgColor: UIColor?
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -66,7 +66,11 @@ class UpdateProfileVC: UIViewController {
         
         AuthService.instance.updateUserById(name: name, email: email, avatarName: avatarName, avatarColor: avatarColor, userId: UserDataService.instance.id) { (success) in
             if success {
-                NotificationCenter.default.post(name: NOTIF_USER_DATA_DID_CHANGE, object: nil)
+                    AuthService.instance.findUserById { (success) in
+                        if success {
+                            NotificationCenter.default.post(name: NOTIF_USER_DATA_DID_CHANGE, object: nil)
+                        }
+                    }
                 self.dismiss(animated: true, completion: nil)
             } else {
                 print("udpateUser ran into some error?")

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -16,6 +16,7 @@ class UpdateProfileVC: UIViewController {
     @IBOutlet weak var passTxt: UITextField!
     @IBOutlet weak var userImg: UIImageView!
     @IBOutlet weak var spinner: UIActivityIndicatorView!
+    @IBOutlet weak var updateProfileBtn: RoundedButton!
     
     
     //MARK: Variables
@@ -39,7 +40,9 @@ class UpdateProfileVC: UIViewController {
         emailTxt.text = UserDataService.instance.email
         userImg.image = UIImage(named: UserDataService.instance.avatarName)
         userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
-
+        spinner.isHidden = true
+        updateProfileBtn.isUserInteractionEnabled = false
+        updateProfileBtn.alpha = 0.5
     }
 
 }

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -29,6 +29,14 @@ class UpdateProfileVC: UIViewController {
         // Do any additional setup after loading the view.
         setupView()
     }
+    
+    @IBAction func pickAvatarPressed(_ sender: Any) {
+        let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
+        let avatarPicker = mainStoryboard.instantiateViewController(withIdentifier: "AvatarPicker")
+        avatarPicker.modalPresentationStyle = .custom
+        present(avatarPicker, animated: true, completion: nil)
+    }
+    
 
     @IBAction func closeBtnPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -36,6 +36,25 @@ class UpdateProfileVC: UIViewController {
         present(avatarPicker, animated: true, completion: nil)
     }
     
+    @IBAction func generateBGColoPressed(_ sender: Any) {
+        let r = CGFloat(arc4random_uniform(255)) / 255
+        let g = CGFloat(arc4random_uniform(255)) / 255
+        let b = CGFloat(arc4random_uniform(255)) / 255
+        
+        bgColor = UIColor(red: r, green: g, blue: b, alpha: 1)
+        //It seems this is done in a very complicated way.
+        //Why don't we just set avatarColor to be of type UIColor
+        //and just pass the value of bgColor to it.
+        //Just a question I have, I don't know if this would actually work.
+        avatarColor = "[\(r), \(g), \(b), 1]"
+        
+        // Animate the transition from one background color to another
+        UIView.animate(withDuration: 0.2) {
+            self.userImg.backgroundColor = self.bgColor
+        }
+    }
+    
+    
 
     @IBAction func closeBtnPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -13,7 +13,6 @@ class UpdateProfileVC: UIViewController {
     //MARK: Outlets
     @IBOutlet weak var usernameTxt: UITextField!
     @IBOutlet weak var emailTxt: UITextField!
-    @IBOutlet weak var passTxt: UITextField!
     @IBOutlet weak var userImg: UIImageView!
     @IBOutlet weak var spinner: UIActivityIndicatorView!
     @IBOutlet weak var updateProfileBtn: RoundedButton!

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -77,6 +77,11 @@ class UpdateProfileVC: UIViewController {
         userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
         spinner.isHidden = true
         disableUpdateProfileBtn()
+        
+        // Be able to dismiss the keyboard when you tap anywhere in the view
+        let tap = UITapGestureRecognizer(target: self.view, action: #selector(UIView.endEditing(_:)))
+        tap.cancelsTouchesInView = false
+        self.view.addGestureRecognizer(tap)
     }
 
 }

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -19,7 +19,7 @@ class UpdateProfileVC: UIViewController {
     
     //MARK: Variables
     var avatarName = "profileDefault"
-    var avatarColor = "[0.5, 0.5, 0.5, 1]"
+    var avatarColor = DEFAULT_AVATAR_COLOR
     var bgColor: UIColor?
     var originalUserImg: UIImage?
     
@@ -70,7 +70,7 @@ class UpdateProfileVC: UIViewController {
     
     @IBAction func profileValuesDidEndEditing(_ sender: Any) {
         print("***** \n username - Editing Did End! \n*****")
-        if usernameTxt.text != UserDataService.instance.name || emailTxt.text != UserDataService.instance.email {
+        if usernameTxt.text != UserDataService.instance.name || emailTxt.text != UserDataService.instance.email || userImg.image != originalUserImg || avatarColor != DEFAULT_AVATAR_COLOR {
             enableUpdateProfileBtn()
             print("***** \n UpdateProfileBtn should be enabled! \n*****")
         } else {

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -60,6 +60,21 @@ class UpdateProfileVC: UIViewController {
         }
     }
     
+    @IBAction func updateProfilePressed(_ sender: Any) {
+        guard let name = usernameTxt.text, usernameTxt.text != "" else { return }
+        guard let email = emailTxt.text, emailTxt.text != "" else { return }
+        
+        AuthService.instance.updateUserById(name: name, email: email, avatarName: avatarName, avatarColor: avatarColor, userId: UserDataService.instance.id) { (success) in
+            if success {
+                NotificationCenter.default.post(name: NOTIF_USER_DATA_DID_CHANGE, object: nil)
+                self.dismiss(animated: true, completion: nil)
+            } else {
+                print("udpateUser ran into some error?")
+                print("The description of success is: \(success.description)")
+            }
+        }
+    }
+    
     @IBAction func closeBtnPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }
@@ -70,7 +85,7 @@ class UpdateProfileVC: UIViewController {
     
     @IBAction func profileValuesDidEndEditing(_ sender: Any) {
         print("***** \n username - Editing Did End! \n*****")
-        if usernameTxt.text != UserDataService.instance.name || emailTxt.text != UserDataService.instance.email || userImg.image != originalUserImg || avatarColor != DEFAULT_AVATAR_COLOR {
+        if usernameTxt.text != UserDataService.instance.name || emailTxt.text != UserDataService.instance.email || userImg.image != originalUserImg || avatarColor != UserDataService.instance.avatarColor {
             enableUpdateProfileBtn()
             print("***** \n UpdateProfileBtn should be enabled! \n*****")
         } else {
@@ -101,10 +116,15 @@ class UpdateProfileVC: UIViewController {
     func setupView() {
         usernameTxt.text = UserDataService.instance.name
         emailTxt.text = UserDataService.instance.email
-        originalUserImg = UIImage(named: UserDataService.instance.avatarName)
+        
+        avatarName = UserDataService.instance.avatarName
+        originalUserImg = UIImage(named: avatarName)
         print("setupView - originalUserImg: \(originalUserImg)")
         userImg.image = originalUserImg
-        userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
+        
+        avatarColor = UserDataService.instance.avatarColor
+        userImg.backgroundColor = UserDataService.instance.returnUIColor(components: avatarColor)
+        
         spinner.isHidden = true
         disableUpdateProfileBtn()
         

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -9,16 +9,37 @@
 import UIKit
 
 class UpdateProfileVC: UIViewController {
+    
+    //MARK: Outlets
+    @IBOutlet weak var usernameTxt: UITextField!
+    @IBOutlet weak var emailTxt: UITextField!
+    @IBOutlet weak var passTxt: UITextField!
+    @IBOutlet weak var userImg: UIImageView!
+    @IBOutlet weak var spinner: UIActivityIndicatorView!
+    
+    
+    //MARK: Variables
+    var avatarName = "profileDefault"
+    var avatarColor = "[0.5, 0.5, 0.5, 1]"
+    var bgColor: UIColor?
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        setupView()
     }
 
     @IBAction func closeBtnPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }
     
+    func setupView() {
+        usernameTxt.text = UserDataService.instance.name
+        emailTxt.text = UserDataService.instance.email
+        userImg.image = UIImage(named: UserDataService.instance.avatarName)
+        userImg.backgroundColor = UserDataService.instance.returnUIColor(components: UserDataService.instance.avatarColor)
+
+    }
 
 }

--- a/Smack/Smack/Controller/UpdateProfileVC.swift
+++ b/Smack/Smack/Controller/UpdateProfileVC.swift
@@ -1,0 +1,24 @@
+//
+//  UpdateProfileVC.swift
+//  Smack
+//
+//  Created by Sebastian Horatiu on 03/03/2019.
+//  Copyright © 2019 Sebastian Horatiu. All rights reserved.
+//
+
+import UIKit
+
+class UpdateProfileVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+    @IBAction func closeBtnPressed(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
+    }
+    
+
+}

--- a/Smack/Smack/Services/AuthService.swift
+++ b/Smack/Smack/Services/AuthService.swift
@@ -154,6 +154,46 @@ class AuthService {
         }
     }
     
+    func updateUserById(name: String, email: String, avatarName: String, avatarColor: String, userId: String, completion: @escaping CompletionHandler) {
+        let lowerCaseEmail = email.lowercased()
+        let body: [String: Any] = [
+            "name": name,
+            "email": lowerCaseEmail,
+            "avatarName": avatarName,
+            "avatarColor": avatarColor
+        ]
+        
+        print("***** body is: \(body)")
+        print("***** Calling Alamofire.request with the following parameters: \n\t url: \(URL_UPDATE_USER_BY_ID), \n\t body: \(body), \n\t header: \(BEARER_HEADER)")
+        
+        Alamofire.request("\(URL_UPDATE_USER_BY_ID)/\(userId)", method: .put, parameters: body, encoding: JSONEncoding.default, headers: BEARER_HEADER).responseJSON { (response) in
+            if response.result.error == nil {
+                print("ResponseJSON has no errors.")
+                print("Response is: \(String(describing: response.result.value))")
+                //                guard let data = response.result.value else { return }
+                
+//                guard let data = response.data else { return }
+//                print("data is \(data)")
+                //                try? JSON(data: $0) - As used in the JSON definition
+                //                guard let json = try? JSON(data: data) else { return }
+//                self.setUserInfo(data: data)
+                
+                UserDataService.instance.setUserData(id: userId, color: avatarColor, avatarName: avatarName, email: lowerCaseEmail, name: name)
+                
+                completion (true)
+            } else {
+                print("Error in responseJSON")
+                completion(false)
+                debugPrint(response.result.error as Any)
+            }
+//            "avatarColor": "[0.474509803921569, 0.768627450980392, 0.227450980392157, 1]",
+//            "avatarName": "light27",
+//            "email": "girrafe2@email.com",
+//            "name": "Ms. Giraffe",
+//            "__v": 0
+        }
+    }
+    
     func setUserInfo(data: Data) {
         let json = JSON(data)
         print("json is \(json)")

--- a/Smack/Smack/Services/AuthService.swift
+++ b/Smack/Smack/Services/AuthService.swift
@@ -154,6 +154,29 @@ class AuthService {
         }
     }
     
+    func findUserById(completion: @escaping CompletionHandler) {
+        print("findUserById, making the Alamofire request to URL: \(URL_USER_BY_ID)\(UserDataService.instance.id)")
+        print("\t header is: \(BEARER_HEADER)")
+        Alamofire.request("\(URL_USER_BY_ID)\(UserDataService.instance.id)", method: .get, parameters: nil, encoding: JSONEncoding.default, headers: BEARER_HEADER).responseJSON { (response) in
+            if response.result.error == nil {
+                print("\t ResponseJSON has no errors.")
+                print("\t Response is: \(String(describing: response.result.value))")
+                //                guard let data = response.result.value else { return }
+                guard let data = response.data else { return }
+                print("\t data is \(data)")
+                //                try? JSON(data: $0) - As used in the JSON definition
+                //                guard let json = try? JSON(data: data) else { return }
+                self.setUserInfo(data: data)
+                
+                completion (true)
+            } else {
+                print("\t Error in responseJSON")
+                completion(false)
+                debugPrint(response.result.error as Any)
+            }
+        }
+    }
+    
     func updateUserById(name: String, email: String, avatarName: String, avatarColor: String, userId: String, completion: @escaping CompletionHandler) {
         let lowerCaseEmail = email.lowercased()
         let body: [String: Any] = [
@@ -163,34 +186,20 @@ class AuthService {
             "avatarColor": avatarColor
         ]
         
-        print("***** body is: \(body)")
-        print("***** Calling Alamofire.request with the following parameters: \n\t url: \(URL_UPDATE_USER_BY_ID), \n\t body: \(body), \n\t header: \(BEARER_HEADER)")
+        print("***** updateUserById, body is: \(body)")
+        print("***** updateUserById, Calling Alamofire.request with the following parameters: \n\t url: \(URL_UPDATE_USER_BY_ID), \n\t body: \(body), \n\t header: \(BEARER_HEADER)")
         
         Alamofire.request("\(URL_UPDATE_USER_BY_ID)/\(userId)", method: .put, parameters: body, encoding: JSONEncoding.default, headers: BEARER_HEADER).responseJSON { (response) in
             if response.result.error == nil {
-                print("ResponseJSON has no errors.")
-                print("Response is: \(String(describing: response.result.value))")
-                //                guard let data = response.result.value else { return }
-                
-//                guard let data = response.data else { return }
-//                print("data is \(data)")
-                //                try? JSON(data: $0) - As used in the JSON definition
-                //                guard let json = try? JSON(data: data) else { return }
-//                self.setUserInfo(data: data)
-                
-                UserDataService.instance.setUserData(id: userId, color: avatarColor, avatarName: avatarName, email: lowerCaseEmail, name: name)
+                print("\t *****ResponseJSON has no errors.")
+                print("\t *****Response is: \(String(describing: response.result.value))")
                 
                 completion (true)
             } else {
-                print("Error in responseJSON")
+                print("\t Error in responseJSON")
                 completion(false)
                 debugPrint(response.result.error as Any)
             }
-//            "avatarColor": "[0.474509803921569, 0.768627450980392, 0.227450980392157, 1]",
-//            "avatarName": "light27",
-//            "email": "girrafe2@email.com",
-//            "name": "Ms. Giraffe",
-//            "__v": 0
         }
     }
     

--- a/Smack/Smack/Services/MessageService.swift
+++ b/Smack/Smack/Services/MessageService.swift
@@ -25,6 +25,9 @@ class MessageService {
             if response.result.error == nil {
                 guard let data = response.data else { return }
                 if let json = JSON(data).array {
+                    //First clean the channes array, so that we don't duplicate them.
+                    //Had this issue before adding this line
+                    self.channels.removeAll()
                     for item in json {
                         let name = item["name"].stringValue
                         let description = item["description"].stringValue

--- a/Smack/Smack/Services/MessageService.swift
+++ b/Smack/Smack/Services/MessageService.swift
@@ -41,7 +41,7 @@ class MessageService {
                     //                    debugPrint(error)
                     //                }
                 }
-                print("These are all the available channels: \(self.channels)")
+//                print("These are all the available channels: \(self.channels)")
                 NotificationCenter.default.post(name: NOTIF_CHANNELS_LOADED, object: nil)
                 completion(true)
             } else {

--- a/Smack/Smack/Services/UserDataService.swift
+++ b/Smack/Smack/Services/UserDataService.swift
@@ -19,7 +19,7 @@ class UserDataService {
     public private(set) var name = ""
     
     func setUserData(id: String, color: String, avatarName: String, email: String, name: String) {
-        print("Inside setUSetUserData with parameters: \(id, color, avatarName, email, name)")
+        print("Inside setUSetUserData with parameters: \((id, color, avatarName, email, name))")
         self.id = id
         self.avatarColor = color
         self.avatarName = avatarName

--- a/Smack/Smack/Utilities/Constants.swift
+++ b/Smack/Smack/Utilities/Constants.swift
@@ -39,6 +39,7 @@ let BEARER_HEADER = [
 
 //MARK: Colors
 let smackPurplePlaceholder = #colorLiteral(red: 0.2588235294, green: 0.3294117647, blue: 0.7254901961, alpha: 0.5)
+let DEFAULT_AVATAR_COLOR = "[0.5, 0.5, 0.5, 1]"
 
 //MARK: Notification Constants
 let NOTIF_USER_DATA_DID_CHANGE = Notification.Name("notifUserDataChanged")

--- a/Smack/Smack/Utilities/Constants.swift
+++ b/Smack/Smack/Utilities/Constants.swift
@@ -18,6 +18,7 @@ let URL_USER_ADD = "\(BASE_URL)user/add"
 let URL_USER_BY_EMAIL = "\(BASE_URL)/user/byEmail/"
 let URL_GET_CHANNELS = "\(BASE_URL)channel"
 let URL_GET_MESSAGES = "\(BASE_URL)message/byChannel/"
+let URL_UPDATE_USER_BY_ID = "\(BASE_URL)user/"
 
 //MARK: Segues
 let TO_LOGIN = "toLogin"

--- a/Smack/Smack/Utilities/Constants.swift
+++ b/Smack/Smack/Utilities/Constants.swift
@@ -19,6 +19,7 @@ let URL_USER_BY_EMAIL = "\(BASE_URL)/user/byEmail/"
 let URL_GET_CHANNELS = "\(BASE_URL)channel"
 let URL_GET_MESSAGES = "\(BASE_URL)message/byChannel/"
 let URL_UPDATE_USER_BY_ID = "\(BASE_URL)user/"
+let URL_USER_BY_ID = "\(BASE_URL)user/"
 
 //MARK: Segues
 let TO_LOGIN = "toLogin"

--- a/Smack/Smack/XIBs/ProfileVC.xib
+++ b/Smack/Smack/XIBs/ProfileVC.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -42,20 +41,20 @@
                             <rect key="frame" x="81.5" y="52.5" width="172.5" height="205.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3p9-Mn-RHx">
-                                    <rect key="frame" x="28.5" y="0.0" width="116" height="25.5"/>
+                                    <rect key="frame" x="28" y="0.0" width="116" height="25.5"/>
                                     <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="21"/>
                                     <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profileDefault" translatesAutoresizingMaskIntoConstraints="NO" id="hHk-f9-h7J" customClass="CircleImage" customModule="Smack" customModuleProvider="target">
-                                    <rect key="frame" x="36.5" y="38.5" width="100" height="100"/>
+                                    <rect key="frame" x="36" y="38.5" width="100" height="100"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="100" id="OYD-gf-xOY"/>
                                         <constraint firstAttribute="width" constant="100" id="Zvz-gT-bNL"/>
                                     </constraints>
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97T-lR-rrI">
-                                    <rect key="frame" x="47.5" y="151.5" width="78" height="20.5"/>
+                                    <rect key="frame" x="47" y="151.5" width="78" height="20.5"/>
                                     <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="17"/>
                                     <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
@@ -79,8 +78,20 @@
                                 <action selector="logoutPressed:" destination="-1" eventType="touchUpInside" id="BXd-Na-tBB"/>
                             </connections>
                         </button>
+                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aJm-JE-Qi7">
+                            <rect key="frame" x="129" y="266" width="77" height="26"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
+                            <state key="normal" title="Update profile">
+                                <color key="titleColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </state>
+                            <connections>
+                                <action selector="updateProfilePressed:" destination="-1" eventType="touchUpInside" id="G3G-En-Qtb"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <accessibility key="accessibilityConfiguration" identifier="profileVC"/>
                     <constraints>
                         <constraint firstItem="xQ8-eX-rHY" firstAttribute="centerX" secondItem="BPJ-eV-ZYc" secondAttribute="centerX" id="1oy-SV-Qt2"/>
                         <constraint firstAttribute="trailing" secondItem="JJL-Qg-1Oc" secondAttribute="trailing" constant="8" id="Kan-By-Lfz"/>

--- a/Smack/Smack/XIBs/ProfileVC.xib
+++ b/Smack/Smack/XIBs/ProfileVC.xib
@@ -86,7 +86,7 @@
                                 <color key="titleColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
-                                <action selector="updateProfilePressed:" destination="-1" eventType="touchUpInside" id="G3G-En-Qtb"/>
+                                <action selector="updateProfilePressed:" destination="-1" eventType="touchUpInside" id="Kex-xT-zBO"/>
                             </connections>
                         </button>
                     </subviews>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -14,6 +14,7 @@
                 <outlet property="emailTxt" destination="HY9-Qt-Wgh" id="KgF-WT-R3g"/>
                 <outlet property="passTxt" destination="vz5-fz-o6O" id="bbE-sS-Y6N"/>
                 <outlet property="spinner" destination="lFX-sT-ome" id="AAR-xM-qlL"/>
+                <outlet property="updateProfileBtn" destination="3Er-0C-nNH" id="uxn-0V-FVD"/>
                 <outlet property="userImg" destination="Hnk-6H-tst" id="8M8-4V-Fmq"/>
                 <outlet property="usernameTxt" destination="ZsH-VK-ioZ" id="ONx-rO-6uh"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -104,6 +104,9 @@
                             <real key="value" value="5"/>
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="updateProfilePressed:" destination="-1" eventType="touchUpInside" id="iUd-W6-d9x"/>
+                    </connections>
                 </button>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profileDefault" translatesAutoresizingMaskIntoConstraints="NO" id="Hnk-6H-tst" userLabel="User Img" customClass="CircleImage" customModule="Smack" customModuleProvider="target">
                     <rect key="frame" x="137.5" y="351" width="100" height="100"/>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -137,6 +137,7 @@
                     </state>
                     <connections>
                         <action selector="generateBGColoPressed:" destination="-1" eventType="touchUpInside" id="RoE-q6-hIm"/>
+                        <action selector="profileValuesDidEndEditing:" destination="-1" eventType="touchUpInside" id="hX0-Tm-NWM"/>
                     </connections>
                 </button>
                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="lFX-sT-ome">

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UpdateProfileVC" customModule="Smack" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Update Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUI-Jh-hVG">
+                    <rect key="frame" x="122.5" y="60" width="130" height="23"/>
+                    <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="19"/>
+                    <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CEZ-BS-WP1">
+                    <rect key="frame" x="331" y="28" width="28" height="28"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="28" id="hEO-eb-Unh"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="nW1-3c-LXh"/>
+                    </constraints>
+                    <state key="normal" image="closeButton"/>
+                    <connections>
+                        <action selector="closeBtnPressed:" destination="-1" eventType="touchUpInside" id="4gO-jU-5Ji"/>
+                    </connections>
+                </button>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="4a6-34-O5T">
+                    <rect key="frame" x="62.5" y="123" width="250" height="139"/>
+                    <subviews>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZsH-VK-ioZ">
+                            <rect key="frame" x="0.0" y="0.0" width="250" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="250" id="0Uu-OO-W0W"/>
+                            </constraints>
+                            <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textField>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kBb-eu-5JX">
+                            <rect key="frame" x="0.0" y="35" width="250" height="2"/>
+                            <color key="backgroundColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="2" id="HsU-JS-szk"/>
+                                <constraint firstAttribute="width" constant="250" id="O2J-Pj-GdJ"/>
+                            </constraints>
+                        </view>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HY9-Qt-Wgh">
+                            <rect key="frame" x="0.0" y="51" width="250" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="250" id="Clb-mu-p5O"/>
+                            </constraints>
+                            <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <textInputTraits key="textInputTraits" textContentType="email"/>
+                        </textField>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jry-WI-MhY">
+                            <rect key="frame" x="0.0" y="86" width="250" height="2"/>
+                            <color key="backgroundColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="2" id="YyE-zr-kBf"/>
+                                <constraint firstAttribute="width" constant="250" id="l8U-TO-4j2"/>
+                            </constraints>
+                        </view>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vz5-fz-o6O">
+                            <rect key="frame" x="0.0" y="102" width="250" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="250" id="XgH-gd-klH"/>
+                            </constraints>
+                            <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
+                        </textField>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NBq-N1-C96">
+                            <rect key="frame" x="0.0" y="137" width="250" height="2"/>
+                            <color key="backgroundColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="2" id="KsT-NI-G08"/>
+                                <constraint firstAttribute="width" constant="250" id="N2j-yI-SgH"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Er-0C-nNH" customClass="RoundedButton" customModule="Smack" customModuleProvider="target">
+                    <rect key="frame" x="62.5" y="597" width="250" height="50"/>
+                    <color key="backgroundColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="250" id="1W0-3E-WOz"/>
+                        <constraint firstAttribute="height" constant="50" id="a0B-6J-WGj"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
+                    <state key="normal" title="Update Profile">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </button>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profileDefault" translatesAutoresizingMaskIntoConstraints="NO" id="Hnk-6H-tst" userLabel="User Img" customClass="CircleImage" customModule="Smack" customModuleProvider="target">
+                    <rect key="frame" x="137.5" y="302" width="100" height="100"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="100" id="x0S-Ys-d5b"/>
+                        <constraint firstAttribute="width" constant="100" id="y4r-fu-RCO"/>
+                    </constraints>
+                </imageView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WRu-fc-WdP">
+                    <rect key="frame" x="137.5" y="302" width="100" height="130"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="130" id="9FV-lQ-aC5"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
+                    <state key="normal" title="Choose avatar">
+                        <color key="titleColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iiP-Eq-09u">
+                    <rect key="frame" x="62.5" y="436" width="250" height="26"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="26" id="VyY-iF-Mnn"/>
+                        <constraint firstAttribute="width" constant="250" id="y0Z-L2-gnH"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
+                    <state key="normal" title="Generate background color">
+                        <color key="titleColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="Hnk-6H-tst" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="0BH-kl-pwr"/>
+                <constraint firstItem="4a6-34-O5T" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4ia-Cd-DMT"/>
+                <constraint firstItem="WRu-fc-WdP" firstAttribute="top" secondItem="Hnk-6H-tst" secondAttribute="top" id="7Kb-w4-dRG"/>
+                <constraint firstItem="WRu-fc-WdP" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="I6c-Pr-hJX"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3Er-0C-nNH" secondAttribute="bottom" constant="20" id="LC2-dU-rjY"/>
+                <constraint firstItem="hUI-Jh-hVG" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="LwS-IP-iyg"/>
+                <constraint firstItem="CEZ-BS-WP1" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="8" id="MIA-IU-e7D"/>
+                <constraint firstItem="4a6-34-O5T" firstAttribute="top" secondItem="hUI-Jh-hVG" secondAttribute="bottom" constant="40" id="PKT-jI-98U"/>
+                <constraint firstItem="hUI-Jh-hVG" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="40" id="T36-jw-D4q"/>
+                <constraint firstItem="Hnk-6H-tst" firstAttribute="top" secondItem="4a6-34-O5T" secondAttribute="bottom" constant="40" id="XOK-od-W6O"/>
+                <constraint firstItem="WRu-fc-WdP" firstAttribute="width" secondItem="Hnk-6H-tst" secondAttribute="width" id="esa-cy-rDh"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="CEZ-BS-WP1" secondAttribute="trailing" constant="16" id="kjn-hO-LCi"/>
+                <constraint firstItem="iiP-Eq-09u" firstAttribute="top" secondItem="WRu-fc-WdP" secondAttribute="bottom" constant="4" id="nxw-q9-u3w"/>
+                <constraint firstItem="iiP-Eq-09u" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="pd8-TY-Syy"/>
+                <constraint firstItem="3Er-0C-nNH" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="sIr-2W-6bU"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="closeButton" width="28" height="28"/>
+        <image name="profileDefault" width="192" height="192"/>
+    </resources>
+</document>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -12,7 +12,6 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UpdateProfileVC" customModule="Smack" customModuleProvider="target">
             <connections>
                 <outlet property="emailTxt" destination="HY9-Qt-Wgh" id="KgF-WT-R3g"/>
-                <outlet property="passTxt" destination="vz5-fz-o6O" id="bbE-sS-Y6N"/>
                 <outlet property="spinner" destination="lFX-sT-ome" id="AAR-xM-qlL"/>
                 <outlet property="updateProfileBtn" destination="3Er-0C-nNH" id="uxn-0V-FVD"/>
                 <outlet property="userImg" destination="Hnk-6H-tst" id="8M8-4V-Fmq"/>
@@ -53,6 +52,11 @@
                             <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <textInputTraits key="textInputTraits"/>
+                            <connections>
+                                <action selector="profileValuesDidEndEditing:" destination="-1" eventType="editingDidEnd" id="BCN-hv-v7k"/>
+                                <action selector="usernameChanged:" destination="-1" eventType="editingChanged" id="b1K-Me-wBj"/>
+                                <action selector="usernameValueChanged:" destination="-1" eventType="valueChanged" id="pVJ-sd-Aj5"/>
+                            </connections>
                         </textField>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kBb-eu-5JX">
                             <rect key="frame" x="0.0" y="35" width="250" height="2"/>
@@ -70,6 +74,9 @@
                             <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <textInputTraits key="textInputTraits" textContentType="email"/>
+                            <connections>
+                                <action selector="profileValuesDidEndEditing:" destination="-1" eventType="editingDidEnd" id="vkg-qm-y3a"/>
+                            </connections>
                         </textField>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jry-WI-MhY">
                             <rect key="frame" x="0.0" y="86" width="250" height="2"/>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -121,6 +121,9 @@
                     <state key="normal" title="Choose avatar">
                         <color key="titleColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
+                    <connections>
+                        <action selector="pickAvatarPressed:" destination="-1" eventType="touchUpInside" id="P4H-wz-TkN"/>
+                    </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iiP-Eq-09u">
                     <rect key="frame" x="62.5" y="485" width="250" height="26"/>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -11,6 +11,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UpdateProfileVC" customModule="Smack" customModuleProvider="target">
             <connections>
+                <outlet property="emailTxt" destination="HY9-Qt-Wgh" id="KgF-WT-R3g"/>
+                <outlet property="passTxt" destination="vz5-fz-o6O" id="bbE-sS-Y6N"/>
+                <outlet property="spinner" destination="lFX-sT-ome" id="AAR-xM-qlL"/>
+                <outlet property="userImg" destination="Hnk-6H-tst" id="8M8-4V-Fmq"/>
+                <outlet property="usernameTxt" destination="ZsH-VK-ioZ" id="ONx-rO-6uh"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -137,11 +142,17 @@
                         <color key="titleColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                 </button>
+                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="lFX-sT-ome">
+                    <rect key="frame" x="169" y="263" width="37" height="38"/>
+                    <color key="color" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </activityIndicatorView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="Hnk-6H-tst" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="0BH-kl-pwr"/>
+                <constraint firstItem="lFX-sT-ome" firstAttribute="top" secondItem="4a6-34-O5T" secondAttribute="bottom" constant="1" id="20W-LL-CN8"/>
                 <constraint firstItem="4a6-34-O5T" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4ia-Cd-DMT"/>
+                <constraint firstItem="lFX-sT-ome" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4uP-WY-k1t"/>
                 <constraint firstItem="WRu-fc-WdP" firstAttribute="top" secondItem="Hnk-6H-tst" secondAttribute="top" id="7Kb-w4-dRG"/>
                 <constraint firstItem="WRu-fc-WdP" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="I6c-Pr-hJX"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3Er-0C-nNH" secondAttribute="bottom" constant="20" id="LC2-dU-rjY"/>
@@ -155,6 +166,7 @@
                 <constraint firstItem="iiP-Eq-09u" firstAttribute="top" secondItem="WRu-fc-WdP" secondAttribute="bottom" constant="4" id="nxw-q9-u3w"/>
                 <constraint firstItem="iiP-Eq-09u" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="pd8-TY-Syy"/>
                 <constraint firstItem="3Er-0C-nNH" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="sIr-2W-6bU"/>
+                <constraint firstItem="Hnk-6H-tst" firstAttribute="top" secondItem="lFX-sT-ome" secondAttribute="bottom" constant="1" id="y2a-Ay-nr7"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
         </view>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -135,6 +135,9 @@
                     <state key="normal" title="Generate background color">
                         <color key="titleColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
+                    <connections>
+                        <action selector="generateBGColoPressed:" destination="-1" eventType="touchUpInside" id="RoE-q6-hIm"/>
+                    </connections>
                 </button>
                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="lFX-sT-ome">
                     <rect key="frame" x="169" y="312" width="37" height="38"/>

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -54,8 +54,6 @@
                             <textInputTraits key="textInputTraits"/>
                             <connections>
                                 <action selector="profileValuesDidEndEditing:" destination="-1" eventType="editingDidEnd" id="BCN-hv-v7k"/>
-                                <action selector="usernameChanged:" destination="-1" eventType="editingChanged" id="b1K-Me-wBj"/>
-                                <action selector="usernameValueChanged:" destination="-1" eventType="valueChanged" id="pVJ-sd-Aj5"/>
                             </connections>
                         </textField>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kBb-eu-5JX">

--- a/Smack/Smack/XIBs/UpdateProfileVC.xib
+++ b/Smack/Smack/XIBs/UpdateProfileVC.xib
@@ -25,7 +25,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Update Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUI-Jh-hVG">
-                    <rect key="frame" x="122.5" y="60" width="130" height="23"/>
+                    <rect key="frame" x="122.5" y="120" width="130" height="23"/>
                     <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="19"/>
                     <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -42,7 +42,7 @@
                     </connections>
                 </button>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="4a6-34-O5T">
-                    <rect key="frame" x="62.5" y="123" width="250" height="139"/>
+                    <rect key="frame" x="62.5" y="223" width="250" height="88"/>
                     <subviews>
                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZsH-VK-ioZ">
                             <rect key="frame" x="0.0" y="0.0" width="250" height="21"/>
@@ -86,23 +86,6 @@
                                 <constraint firstAttribute="width" constant="250" id="l8U-TO-4j2"/>
                             </constraints>
                         </view>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vz5-fz-o6O">
-                            <rect key="frame" x="0.0" y="102" width="250" height="21"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="250" id="XgH-gd-klH"/>
-                            </constraints>
-                            <color key="textColor" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
-                        </textField>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NBq-N1-C96">
-                            <rect key="frame" x="0.0" y="137" width="250" height="2"/>
-                            <color key="backgroundColor" red="0.35686274509999999" green="0.62352941179999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="2" id="KsT-NI-G08"/>
-                                <constraint firstAttribute="width" constant="250" id="N2j-yI-SgH"/>
-                            </constraints>
-                        </view>
                     </subviews>
                 </stackView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Er-0C-nNH" customClass="RoundedButton" customModule="Smack" customModuleProvider="target">
@@ -123,14 +106,14 @@
                     </userDefinedRuntimeAttributes>
                 </button>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profileDefault" translatesAutoresizingMaskIntoConstraints="NO" id="Hnk-6H-tst" userLabel="User Img" customClass="CircleImage" customModule="Smack" customModuleProvider="target">
-                    <rect key="frame" x="137.5" y="302" width="100" height="100"/>
+                    <rect key="frame" x="137.5" y="351" width="100" height="100"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="100" id="x0S-Ys-d5b"/>
                         <constraint firstAttribute="width" constant="100" id="y4r-fu-RCO"/>
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WRu-fc-WdP">
-                    <rect key="frame" x="137.5" y="302" width="100" height="130"/>
+                    <rect key="frame" x="137.5" y="351" width="100" height="130"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="130" id="9FV-lQ-aC5"/>
                     </constraints>
@@ -140,7 +123,7 @@
                     </state>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iiP-Eq-09u">
-                    <rect key="frame" x="62.5" y="436" width="250" height="26"/>
+                    <rect key="frame" x="62.5" y="485" width="250" height="26"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="26" id="VyY-iF-Mnn"/>
                         <constraint firstAttribute="width" constant="250" id="y0Z-L2-gnH"/>
@@ -151,7 +134,7 @@
                     </state>
                 </button>
                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="lFX-sT-ome">
-                    <rect key="frame" x="169" y="263" width="37" height="38"/>
+                    <rect key="frame" x="169" y="312" width="37" height="38"/>
                     <color key="color" red="0.25882352939999997" green="0.3294117647" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </activityIndicatorView>
             </subviews>
@@ -166,8 +149,8 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3Er-0C-nNH" secondAttribute="bottom" constant="20" id="LC2-dU-rjY"/>
                 <constraint firstItem="hUI-Jh-hVG" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="LwS-IP-iyg"/>
                 <constraint firstItem="CEZ-BS-WP1" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="8" id="MIA-IU-e7D"/>
-                <constraint firstItem="4a6-34-O5T" firstAttribute="top" secondItem="hUI-Jh-hVG" secondAttribute="bottom" constant="40" id="PKT-jI-98U"/>
-                <constraint firstItem="hUI-Jh-hVG" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="40" id="T36-jw-D4q"/>
+                <constraint firstItem="4a6-34-O5T" firstAttribute="top" secondItem="hUI-Jh-hVG" secondAttribute="bottom" constant="80" id="PKT-jI-98U"/>
+                <constraint firstItem="hUI-Jh-hVG" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="100" id="T36-jw-D4q"/>
                 <constraint firstItem="Hnk-6H-tst" firstAttribute="top" secondItem="4a6-34-O5T" secondAttribute="bottom" constant="40" id="XOK-od-W6O"/>
                 <constraint firstItem="WRu-fc-WdP" firstAttribute="width" secondItem="Hnk-6H-tst" secondAttribute="width" id="esa-cy-rDh"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="CEZ-BS-WP1" secondAttribute="trailing" constant="16" id="kjn-hO-LCi"/>


### PR DESCRIPTION
In this branch I've implemented the Update Profile feature which would allow you to update all your profile data: username, email, avatar, avatar colour. You would be able to send an update profile request, only if you change one of these profile values, otherwise the Update Profile button is disabled.

How:
- added an Update profile button in the ProfileVC.xib;
- created an UpdateProfileVC.xib, very similar to the CreateAccountVC from Main.storyboard;
- tapping the Update profile button will take you to the UpdateProfileVC.xib;
- created UpdateProfileVC.swift to handle all the logic from UpdateProfileVC.xib;
- when UpdateProfileVC.xib is presented, it has all your current user data profile;
- after you update any of the fields and if the new value is different than the old one, the Update Profile button becomes active;
- after you press the Update Profile button, a call is made to the updateUserById endpoint of the API;
- then, if the call is successful, we call the findUserById in order to fetch the updated user's data from the API;
- then the UpdateProfileVC is dismissed and the Profile VC is presented again, but this time with the newly updated user data;

